### PR TITLE
Updated coffee-script to version 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "description": "Markdown handling components for the NoFlo flow-based programming environment",
   "author": "Henri Bergius <henri.bergius@iki.fi>",
   "version": "0.0.10",
-  "licenses": [{
-    "type": "MIT",
-    "url": "https://github.com/bergie/noflo/raw/master/LICENSE"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/bergie/noflo/raw/master/LICENSE"
+    }
+  ],
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/noflo/noflo-markdown.git"
+    "type": "git",
+    "url": "https://github.com/noflo/noflo-markdown.git"
   },
   "engines": {
     "node": ">=0.6.0"
@@ -22,7 +24,7 @@
   "devDependencies": {
     "noflo-test": "0.0.x",
     "coffeelint": "*",
-    "coffee-script": "1.8.x"
+    "coffee-script": "1.10.0"
   },
   "noflo": {
     "icon": "file-text",


### PR DESCRIPTION
:rocket:

One of your dependencies has just updated, so this PR bumps the corresponding version number in your `package.json`.

You can now check that the dependency update doesn't break your code, and then release the new version of your software safe in the knowledge that it will stay in this working state, regardless of _when_ your users do `$ npm install`.

Have a good day!

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>